### PR TITLE
Add `beforeopen` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,30 @@ Get an array of default items.
 
 ## Events
 
-#### Listen and make some changes before context menu opens
+#### If you want to disable this plugin under certain circumstances, listen to `beforeopen`
+
+```javascript
+contextmenu.on('beforeopen', function(evt){
+  var feature = map.forEachFeatureAtPixel(evt.pixel, function(ft, l){
+    return ft;
+  });
+
+  if (feature) { // open only on features
+    contextmenu.disable();
+  } else {
+    contextmenu.enable();
+  }
+});
+```
+
+#### Listen and make some changes when context menu opens
 
 ```javascript
 contextmenu.on('open', function(evt){
   var feature = map.forEachFeatureAtPixel(evt.pixel, function(ft, l){
     return ft;
   });
+
   if (feature) {
     // add some other items to the menu
   }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -3,6 +3,10 @@ import utils from './utils';
 
 export const eventType = {
   /**
+   * Triggered before context menu is openned.
+   */
+  BEFOREOPEN: 'beforeopen',
+  /**
    * Triggered when context menu is openned.
    */
   OPEN: 'open',

--- a/src/js/internal.js
+++ b/src/js/internal.js
@@ -110,7 +110,7 @@ export class Internal {
     this.Base.dispatchEvent({
       type: constants.eventType.OPEN,
       pixel: pixel,
-      coordinate: coordinate,
+      coordinate: coordinate
     });
   }
 
@@ -130,15 +130,21 @@ export class Internal {
         map = this.map,
         canvas = map.getTargetElement(),
         menu = function(evt) {
+          this_.coordinate_clicked = map.getEventCoordinate(evt);
+          this_.pixel_clicked = map.getEventPixel(evt);
 
+          this_.Base.dispatchEvent({
+            type: constants.eventType.BEFOREOPEN,
+            pixel: this_.pixel_clicked,
+            coordinate: this_.coordinate_clicked
+          });
+          
           if (this_.Base.disabled) {
             return;
           }
 
           evt.stopPropagation();
           evt.preventDefault();
-          this_.coordinate_clicked = map.getEventCoordinate(evt);
-          this_.pixel_clicked = map.getEventPixel(evt);
           this_.openMenu(this_.pixel_clicked, this_.coordinate_clicked);
           
           //one-time fire


### PR DESCRIPTION
If you want to disable this plugin under certain circumstances, listen to `beforeopen`:

```javascript
contextmenu.on('beforeopen', function(evt){
  var feature = map.forEachFeatureAtPixel(evt.pixel, function(ft, l){
    return ft;
  });

  if (feature) { // open only on features
    contextmenu.disable();
  } else {
    contextmenu.enable();
  }
});
```