### PR TITLE
+) Added custom css class to default options

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -8,7 +8,8 @@ CM.Base = function(opt_options){
   
   var defaults = {
     width: 150,
-    default_items: true
+    default_items: true,
+      cssClass: ""
   };
   CM.options = utils.mergeOptions(defaults, opt_options);
   CM.$base = this;

--- a/src/html.js
+++ b/src/html.js
@@ -7,7 +7,7 @@ CM.Html = function(){
 
 CM.Html.prototype = {
   createContainer: function() {
-    var classes = CM.Constants.css;
+    var classes = CM.Constants.css + " " + CM.options.cssClass;
     var container = document.createElement('ul');
     container.className = classes.container +' '+ classes.hidden;
     container.style.width = parseInt(CM.options.width, 10) + 'px';


### PR DESCRIPTION
There should be an option to use custom css classes for each context menu, if you want so show more than one context menu with different container styling.